### PR TITLE
Added isMember Flag to User Community Retrieval & Fixed Response Format

### DIFF
--- a/Backend/MHBackend/Controllers/BookingsController.cs
+++ b/Backend/MHBackend/Controllers/BookingsController.cs
@@ -80,7 +80,7 @@ namespace MHBackend.Controllers
             await _db.SaveChangesAsync();
 
 
-            return Ok("Booking Confirmed");
+            return Ok(new { message = "Booking Confirmed" });
 
 
         }
@@ -118,10 +118,11 @@ namespace MHBackend.Controllers
                 booking.Ticket.Event.Capacity++;
             }
             await _db.SaveChangesAsync();
-            return Ok("Booking Cancelled");
+            return Ok(new { message = "Booking Cancelled" });
 
 
-    }
+
+        }
 
 
 

--- a/Backend/MHBackend/DTOs/CommunityDto.cs
+++ b/Backend/MHBackend/DTOs/CommunityDto.cs
@@ -8,6 +8,7 @@
         public int MemberCount { get; set; }
         public DateTime CreatedAt { get; set; }
         public string? ImageUrl { get; set; }
+        public bool IsMember { get; set; }
 
 
 


### PR DESCRIPTION
changes:
- Added isMember flag :  The GetAllCommunities retrieval endpoint now includes an "isMember" a boolean field to indicate whether the requesting user is a member of each returned community.
- front-end can now check membership status directly in the response without additional API calls.

- Fixed response format – Ensured consistent JSON structure in all responses:
