### PR TITLE
Refactor booking capacity checks to ensure only non-public events enforce capacity limits

### DIFF
--- a/Backend/MHBackend/Controllers/BookingsController.cs
+++ b/Backend/MHBackend/Controllers/BookingsController.cs
@@ -44,9 +44,11 @@ namespace MHBackend.Controllers
                 return BadRequest("Event is not available for booking"); 
 
             // Check capacity 
-            if (eventToBook.Capacity.HasValue &&
-                eventToBook.Tickets.Count(t => t.Status == TicketStatus.Valid) >= eventToBook.Capacity.Value)
-                return BadRequest("Event is Fully Booked");
+            if (eventToBook.EventType != EventType.Public){
+                if (eventToBook.Capacity.HasValue &&
+                    eventToBook.Tickets.Count(t => t.Status == TicketStatus.Valid) >= eventToBook.Capacity.Value)
+                    return BadRequest("Event is Fully Booked");
+            }
             // Check if user already has a booking
             var userBooking = await _db.Bookings
                 .Include(b => b.Ticket)
@@ -74,7 +76,10 @@ namespace MHBackend.Controllers
                 Booking = newBooking,
                 QRCode =  _qRCodeService.GenerateQRCodeAsync($"{newBooking.PublicBookingId}{eventToBook.Title}{eventToBook.Location}"),
             };
-            eventToBook.Capacity--;
+            if (eventToBook.EventType != EventType.Public && eventToBook.Capacity.HasValue)
+            {
+                eventToBook.Capacity--;
+            }
             //  Save to database
             await _db.Tickets.AddAsync(newTicket);
             await _db.SaveChangesAsync();


### PR DESCRIPTION
This pull request updates the `BookEvent` method in `BookingsController` to handle event capacity checks and decrements more accurately based on the event type. The changes ensure that capacity restrictions only apply to non-public events.

### Changes to event capacity handling:

* Added a condition to skip capacity checks for public events when determining if an event is fully booked. (`Backend/MHBackend/Controllers/BookingsController.cs`, [Backend/MHBackend/Controllers/BookingsController.csR47-R51](diffhunk://#diff-49580628174af2fe13c41ada74779daa4c6dad633a96a42c602eaf73515dafd7R47-R51))
* Updated the logic to decrement event capacity only for non-public events when creating a new booking. (`Backend/MHBackend/Controllers/BookingsController.cs`, [Backend/MHBackend/Controllers/BookingsController.csR79-R82](diffhunk://#diff-49580628174af2fe13c41ada74779daa4c6dad633a96a42c602eaf73515dafd7R79-R82))