### PR TITLE
Add AuthService to ManageEventsComponent and update event creation to use logged-in user's ID

### DIFF
--- a/Frontend/MHFrontend/src/app/components/admin-dashboard/manage-events/manage-events.component.ts
+++ b/Frontend/MHFrontend/src/app/components/admin-dashboard/manage-events/manage-events.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { EventFormComponent } from '../event-form/event-form.component';
 import { EventService, Event, EventCreate, EventUpdate } from '../../../services/event/event.service';
-
+import { AuthService } from '../../../services/auth.service'; 
 @Component({
   selector: 'app-manage-events',
   standalone: true,
@@ -36,7 +36,7 @@ export class ManageEventsComponent implements OnInit {
   error: string | null = null;
   successMessage: string | null = null;
 
-  constructor(private eventService: EventService) { }
+  constructor(private eventService: EventService, private authService: AuthService ) { }
   ngOnInit(): void {
     this.loadEvents();
   }
@@ -146,11 +146,11 @@ export class ManageEventsComponent implements OnInit {
       });
     } else {
       // Add new event
+      const userProfile = this.authService.userProfileValue;
       const createData: EventCreate = {
         ...eventData,
         eventType: eventData.eventType === 'public' ? 0 : 1,
-        //TODO: createBy should be set to the logged-in user's ID
-        createdBy: 1, // Hardcoded user ID
+        createdBy: userProfile?.userIdPublic,
       };
       this.eventService.createEvent(createData).subscribe({
         next: (createdEvent) => {


### PR DESCRIPTION
This pull request enhances the `ManageEventsComponent` in the Angular frontend by integrating the `AuthService` to dynamically set the `createdBy` field for new events based on the logged-in user's profile. This change improves the accuracy and security of event creation by removing hardcoded user IDs.

### Integration of `AuthService`:

* [`Frontend/MHFrontend/src/app/components/admin-dashboard/manage-events/manage-events.component.ts`](diffhunk://#diff-2db89a55b1f346019dfee26b7b06174e5a50bbcb6690b00b156b4abd62f1b9b5L6-R6): Imported `AuthService` to access user profile information.
* [`Frontend/MHFrontend/src/app/components/admin-dashboard/manage-events/manage-events.component.ts`](diffhunk://#diff-2db89a55b1f346019dfee26b7b06174e5a50bbcb6690b00b156b4abd62f1b9b5L39-R39): Updated the constructor to inject `AuthService` alongside `EventService`.

### Dynamic assignment of `createdBy`:

* [`Frontend/MHFrontend/src/app/components/admin-dashboard/manage-events/manage-events.component.ts`](diffhunk://#diff-2db89a55b1f346019dfee26b7b06174e5a50bbcb6690b00b156b4abd62f1b9b5R149-R153): Replaced the hardcoded `createdBy` field with `userProfile?.userIdPublic` from `AuthService` when creating a new event. This ensures the `createdBy` field reflects the currently logged-in user.