### PR TITLE
fix: restore date formatting in user list and update formatDate method to handle string or Date input

### DIFF
--- a/Frontend/MHFrontend/src/app/components/admin-dashboard/user-list/user-list.component.html
+++ b/Frontend/MHFrontend/src/app/components/admin-dashboard/user-list/user-list.component.html
@@ -63,7 +63,7 @@
               class="hover:bg-[#fff8f3] transition-colors">
             <td class="p-4 border-t border-gray-200 text-[#E69B6B] font-medium">{{ user.userName }}</td>
             <td class="p-4 border-t border-gray-200">{{ user.phoneNumber }}</td>
-            <!-- <td class="p-4 border-t border-gray-200">{{ formatDate(user.createdAt) }}</td> -->
+            <td class="p-4 border-t border-gray-200">{{ formatDate(user.createdAt) }}</td>
           </tr>
         </tbody>
       </table>
@@ -84,7 +84,7 @@
           </div>
           <div class="flex items-start">
             <span class="w-24 text-gray-500">Created At</span>
-            <!-- <span class="break-all">{{ formatDate(user.createdAt) }}</span> -->
+            <span class="break-all">{{ formatDate(user.createdAt) }}</span>
           </div>
         </div>
       </div>

--- a/Frontend/MHFrontend/src/app/components/admin-dashboard/user-list/user-list.component.ts
+++ b/Frontend/MHFrontend/src/app/components/admin-dashboard/user-list/user-list.component.ts
@@ -126,8 +126,9 @@ export class UserListComponent implements OnInit {
     this.updatePagination();
   }
 
-  formatDate(date: Date): string {
+  formatDate(dateString: string | Date): string {
     // DD/MM/YYYY format
+    const date = new Date(dateString);
     const day = date.getDate().toString().padStart(2, '0');
     const month = (date.getMonth() + 1).toString().padStart(2, '0');
     const year = date.getFullYear();


### PR DESCRIPTION
This pull request updates the `UserListComponent` in the Admin Dashboard to re-enable and enhance the display of user creation dates. The changes include reactivating previously commented-out HTML elements and improving the `formatDate` method to handle both `string` and `Date` inputs.

### Re-enabling display of user creation dates:
* [`user-list.component.html`](diffhunk://#diff-29220f1003468ff66b85afa285876c4eb93b82f2a20f3defd20ef097c91c8cd6L66-R66): Uncommented and re-enabled the display of the `createdAt` field in the user list table and user details section. [[1]](diffhunk://#diff-29220f1003468ff66b85afa285876c4eb93b82f2a20f3defd20ef097c91c8cd6L66-R66) [[2]](diffhunk://#diff-29220f1003468ff66b85afa285876c4eb93b82f2a20f3defd20ef097c91c8cd6L87-R87)

### Enhancements to the `formatDate` method:
* [`user-list.component.ts`](diffhunk://#diff-a13fcf820cf2cfe00411db617e754110ff18b98f63ed4f2b8bcf232e1da1b2a8L129-R131): Modified the `formatDate` method to accept both `string` and `Date` types as input, ensuring better flexibility and reliability when formatting dates.