### PR TITLE
Fixing the issue where base64 (qr code) image was being blocked

### DIFF
--- a/Backend/MHBackend/Controllers/BookingsController.cs
+++ b/Backend/MHBackend/Controllers/BookingsController.cs
@@ -1,4 +1,4 @@
-using MHBackend.Data;
+﻿using MHBackend.Data;
 using MHBackend.DTOs;
 using MHBackend.Models;
 using MHBackend.Repositories;
@@ -106,7 +106,7 @@ namespace MHBackend.Controllers
             }
 
             //well formatted HTML email with the QR code 
-            var htmlBody = $@"
+           var htmlBody = $@"
             <!DOCTYPE html>
             <html>
             <head>
@@ -134,7 +134,7 @@ namespace MHBackend.Controllers
                         
                         <div class='qr-code'>
                             <p>Scan this QR code at the event:</p>
-                            <img src='data:image/png;base64,{qrCodeBytes}' alt='QR Code' style='max-width: 200px;' />
+                            <img src='cid:qrcode' alt='QR Code' style='max-width: 200px;' />
                             <p>Booking Reference: {newBooking.PublicBookingId}</p>
                         </div>
                         

--- a/Backend/MHBackend/Services/EmailService.cs
+++ b/Backend/MHBackend/Services/EmailService.cs
@@ -18,7 +18,7 @@ namespace MHBackend.Services
     {
         private readonly IConfiguration _configuration;
         private readonly ILogger<EmailService> _logger;
-
+        
         public EmailService(IConfiguration configuration, ILogger<EmailService> logger)
         {
             _configuration = configuration;
@@ -36,7 +36,7 @@ namespace MHBackend.Services
                 var smtpPass = _configuration["Email:SmtpPass"];
                 var senderName = _configuration["Email:SenderName"];
                 var senderAddress = _configuration["Email:SenderAddress"];
-
+                
                 // Check for null or empty configuration values
                 if (string.IsNullOrWhiteSpace(smtpHost) || string.IsNullOrWhiteSpace(smtpPortStr) ||
                     string.IsNullOrWhiteSpace(smtpUser) || string.IsNullOrWhiteSpace(smtpPass) ||
@@ -45,7 +45,7 @@ namespace MHBackend.Services
                     _logger.LogError("Email service configuration is incomplete. Check your appsettings.json file.");
                     return false;
                 }
-
+                
                 // Parse port number
                 if (!int.TryParse(smtpPortStr, out int smtpPort))
                 {
@@ -53,35 +53,76 @@ namespace MHBackend.Services
                     return false;
                 }
 
-                var message = new MimeMessage();
+                var message = new MimeKit.MimeMessage();
                 message.From.Add(new MailboxAddress(senderName ?? "Event System", senderAddress));
                 message.To.Add(MailboxAddress.Parse(toEmail));
                 message.Subject = subject;
 
-                var builder = new BodyBuilder
+                // Create linked resources for the QR code image
+                var image = new MimePart("image", "png")
                 {
-                    HtmlBody = htmlBody
+                    Content = new MimeContent(new MemoryStream(qrCodeBytes)),
+                    ContentId = "qrcode", // Set a content ID for referencing in the HTML
+                    ContentDisposition = new ContentDisposition(ContentDisposition.Inline),
+                    ContentTransferEncoding = ContentEncoding.Base64,
+                    FileName = attachmentName ?? "qrcode.png"
                 };
 
-                // Add QR code as attachment
-                if (qrCodeBytes != null)
+                // Modify HTML body to use content ID reference instead of inline base64
+                // This is more reliable and fixes the display issue
+                var modifiedHtmlBody = htmlBody.Replace(
+                    $"src='data:image/png;base64,{Convert.ToBase64String(qrCodeBytes)}'",
+                    "src=\"cid:qrcode\""
+                );
+
+                // If the direct replacement didn't work (likely because the base64 in HTML differs),
+                // use a more general approach to find and replace the image tag
+                if (modifiedHtmlBody == htmlBody)
                 {
-                    builder.Attachments.Add(attachmentName ?? "qrcode.png", qrCodeBytes, new ContentType("image", "png"));
+                    modifiedHtmlBody = System.Text.RegularExpressions.Regex.Replace(
+                        htmlBody,
+                        "src=['\"]data:image/png;base64,[^'\"]+['\"]",
+                        "src=\"cid:qrcode\""
+                    );
                 }
 
-                message.Body = builder.ToMessageBody();
+                var htmlPart = new TextPart("html")
+                {
+                    Text = modifiedHtmlBody
+                };
+
+                // Create multipart/related container for HTML and embedded image
+                var multipartRelated = new MultipartRelated
+                {
+                    htmlPart,
+                    image
+                };
+
+                // Also attach the QR code as a separate attachment
+                var attachment = new MimePart("image", "png")
+                {
+                    Content = new MimeContent(new MemoryStream(qrCodeBytes)),
+                    ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
+                    ContentTransferEncoding = ContentEncoding.Base64,
+                    FileName = attachmentName ?? "qrcode.png"
+                };
+
+                // Create multipart/mixed container for the related content and attachment
+                var multipartMixed = new Multipart("mixed")
+                {
+                    multipartRelated,
+                    attachment
+                };
+
+                message.Body = multipartMixed;
 
                 using var client = new SmtpClient();
-                
                 _logger.LogInformation($"Connecting to SMTP server {smtpHost}:{smtpPort}");
                 await client.ConnectAsync(smtpHost, smtpPort, SecureSocketOptions.StartTls);
-
                 _logger.LogInformation("Authenticating with SMTP server");
                 await client.AuthenticateAsync(smtpUser, smtpPass);
-
                 _logger.LogInformation($"Sending email to {toEmail}");
                 await client.SendAsync(message);
-                
                 _logger.LogInformation("Email sent successfully");
                 await client.DisconnectAsync(true);
                 


### PR DESCRIPTION
The issue was that Gmail blocks inline base64 images in emails, preventing the QR code from displaying. Solved it by replacing the base64-encoded image with a Content-ID reference (src='cid:qrcode') which properly links to the attached image while maintaining email client compatibility.